### PR TITLE
fix deprecation of XmlBuilder.doc/1

### DIFF
--- a/lib/atomex.ex
+++ b/lib/atomex.ex
@@ -13,7 +13,9 @@ defmodule Atomex do
   """
   @spec generate_document(Atomex.Feed.t()) :: binary()
   def generate_document(feed) do
-    XmlBuilder.doc(feed)
+    feed
+    |> XmlBuilder.document()
+    |> XmlBuilder.generate()
   end
 
   @spec version() :: binary()


### PR DESCRIPTION
The deprecation was introduced in XmlBuilder 2.1.0:
https://github.com/joshnuss/xml_builder/pull/28